### PR TITLE
Add new benchmark: mixing with gains

### DIFF
--- a/benchmarks.js
+++ b/benchmarks.js
@@ -137,6 +137,36 @@ registerTestCase({
 
 registerTestCase({
   func: function() {
+    var oac = new OfflineAudioContext(2, 300 * samplerate, samplerate);
+    var gain = oac.createGain();
+    gain.gain.value = -1;
+    gain.connect(oac.destination);
+    var gainsi = [];
+    for (var i = 0; i < 4; i++) {
+      var gaini = oac.createGain();
+      gaini.gain.value = 0.25;
+      gaini.connect(gain);
+      gainsi[i] = gaini
+    }
+    for (var j = 0; j < 2; j++) {
+      var sourcej = oac.createBufferSource();
+      sourcej.buffer = getSpecificFile({rate: 38000, channels:1});
+      sourcej.loop = true;
+      sourcej.start(0);
+      for (var i = 0; i < 4; i++) {
+        var gainij = oac.createGain();
+        gainij.gain.value = 0.5;
+        gainij.connect(gainsi[i]);
+        sourcej.connect(gainij);
+      }
+    }
+    return oac;
+  },
+  name: "Simple mixing with gains"
+});
+
+registerTestCase({
+  func: function() {
     var oac = new OfflineAudioContext(1, 30 * samplerate, samplerate);
     var i,l;
     var decay = 10;

--- a/webaudio.json
+++ b/webaudio.json
@@ -2854,6 +2854,322 @@
       ]
     },
     {
+      "title": "Simple mixing with gains -- win",
+      "height": "250px",
+      "editable": true,
+      "collapse": true,
+      "panels": [
+        {
+          "title": "Simple mixing with gains -- win",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": true,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "alignAsTable": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple mixing with gains.win.firefox.nightly",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple mixing with gains.win.firefox.nightly\" where $timeFilter group by time($interval) order asc",
+              "hide": false
+            },
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple mixing with gains.win.chrome.canary",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple mixing with gains.win.chrome.canary\" where $timeFilter group by time($interval) order asc",
+              "hide": false,
+              "groupby_field": ""
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "leftYAxisLabel": "Time in milliseconds, lower is better"
+        }
+      ]
+    },
+    {
+      "title": "Simple mixing with gains -- linux",
+      "height": "250px",
+      "editable": true,
+      "collapse": true,
+      "panels": [
+        {
+          "title": "Simple mixing with gains -- linux",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": true,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "alignAsTable": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple mixing with gains.linux.firefox.nightly",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple mixing with gains.linux.firefox.nightly\" where $timeFilter group by time($interval) order asc",
+              "hide": false
+            },
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple mixing with gains.linux.chrome.canary",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple mixing with gains.linux.chrome.canary\" where $timeFilter group by time($interval) order asc",
+              "hide": false,
+              "groupby_field": ""
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "leftYAxisLabel": "Time in milliseconds, lower is better"
+        }
+      ]
+    },
+    {
+      "title": "Simple mixing with gains -- mac",
+      "height": "250px",
+      "editable": true,
+      "collapse": true,
+      "panels": [
+        {
+          "title": "Simple mixing with gains -- mac",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": true,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "alignAsTable": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple mixing with gains.mac.firefox.nightly",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple mixing with gains.mac.firefox.nightly\" where $timeFilter group by time($interval) order asc",
+              "hide": false
+            },
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple mixing with gains.mac.chrome.canary",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple mixing with gains.mac.chrome.canary\" where $timeFilter group by time($interval) order asc",
+              "hide": false,
+              "groupby_field": ""
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "leftYAxisLabel": "Time in milliseconds, lower is better"
+        }
+      ]
+    },
+    {
+      "title": "Simple mixing with gains -- android",
+      "height": "250px",
+      "editable": true,
+      "collapse": true,
+      "panels": [
+        {
+          "title": "Simple mixing with gains -- android",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": true,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "alignAsTable": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple mixing with gains.android.firefox.nightly",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple mixing with gains.android.firefox.nightly\" where $timeFilter group by time($interval) order asc",
+              "hide": false
+            },
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple mixing with gains.android.chrome.canary",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple mixing with gains.android.chrome.canary\" where $timeFilter group by time($interval) order asc",
+              "hide": false,
+              "groupby_field": ""
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "leftYAxisLabel": "Time in milliseconds, lower is better"
+        }
+      ]
+    },
+    {
       "title": "Convolution reverb -- win",
       "height": "250px",
       "editable": true,


### PR DESCRIPTION
Gain nodes are used frequently in complex graphs.
This tests the performance of gain nodes and mixing inputs.
