### PR TITLE
[fix] loading, decoding and retrieving audio files

### DIFF
--- a/benchmarks.js
+++ b/benchmarks.js
@@ -29,7 +29,7 @@ registerTestCase({
     source0.start(0);
     return oac;
   },
-  name: "Simple gain test without resampling"
+  name: "Simple source test without resampling"
 });
 
 registerTestCase({
@@ -42,7 +42,7 @@ registerTestCase({
     source0.start(0);
     return oac;
   },
-  name: "Simple gain test without resampling (Stereo)"
+  name: "Simple source test without resampling (Stereo)"
 });
 
 registerTestCase({
@@ -59,7 +59,7 @@ registerTestCase({
     source0.start(0);
     return oac;
   },
-  name: "Simple gain test without resampling (Stereo and positional)"
+  name: "Simple source test without resampling (Stereo and positional)"
 });
 
 registerTestCase({
@@ -72,7 +72,7 @@ registerTestCase({
     source0.start(0);
     return oac;
   },
-  name: "Simple gain test"
+  name: "Simple source test with resampling (Mono)"
 });
 
 registerTestCase({
@@ -85,7 +85,7 @@ registerTestCase({
     source0.start(0);
     return oac;
   },
-  name: "Simple gain test (Stereo)"
+  name: "Simple source test with resampling (Stereo)"
 });
 
 registerTestCase({
@@ -102,7 +102,7 @@ registerTestCase({
     source0.start(0);
     return oac;
   },
-  name: "Simple gain test (Stereo and positional)"
+  name: "Simple source test with resampling (Stereo and positional)"
 });
 
 registerTestCase({
@@ -128,7 +128,7 @@ registerTestCase({
     source0.start(0);
     return oac;
   },
-  name: "Downmix without resampling (Mono -> Stereo)"
+  name: "Downmix without resampling (Stereo -> Mono)"
 });
 
 registerTestCase({
@@ -144,7 +144,7 @@ registerTestCase({
     }
     return oac;
   },
-  name: "Simple mixing (same buffer)"
+  name: "Simple mixing (100x same buffer)"
 });
 
 registerTestCase({
@@ -168,7 +168,7 @@ registerTestCase({
     }
     return oac;
   },
-  name: "Simple mixing (different buffers)"
+  name: "Simple mixing (100 different buffers)"
 });
 
 registerTestCase({

--- a/benchmarks.js
+++ b/benchmarks.js
@@ -4,16 +4,16 @@ if (typeof(window) == "undefined") {
   registerTestCase = function(o) { return benchmarks.push(o.name); }
 }
 
-registerTestFile("think-mono-48000.wav");
-registerTestFile("think-mono-44100.wav");
-registerTestFile("think-mono-38000.wav");
-registerTestFile("think-stereo-48000.wav");
-registerTestFile("think-stereo-44100.wav");
-registerTestFile("think-stereo-38000.wav");
+registerTestFile({ sampleRate: 48000, url: "think-mono-48000.wav" });
+registerTestFile({ sampleRate: 44100, url: "think-mono-44100.wav" });
+registerTestFile({ sampleRate: 38000, url: "think-mono-38000.wav" });
+registerTestFile({ sampleRate: 48000, url: "think-stereo-48000.wav" });
+registerTestFile({ sampleRate: 44100, url: "think-stereo-44100.wav" });
+registerTestFile({ sampleRate: 38000, url: "think-stereo-38000.wav" });
 
 registerTestCase({
   func: function () {
-    var oac = new OfflineAudioContext(1, DURATION * samplerate, samplerate);
+    var oac = new OfflineAudioContext(1, DURATION * sampleRate, sampleRate);
     return oac;
   },
   name: "Empty testcase"
@@ -21,9 +21,9 @@ registerTestCase({
 
 registerTestCase({
   func: function () {
-    var oac = new OfflineAudioContext(1, DURATION * samplerate, samplerate);
+    var oac = new OfflineAudioContext(1, DURATION * sampleRate, sampleRate);
     var source0 = oac.createBufferSource();
-    source0.buffer = getSpecificFile({rate: oac.samplerate, channels:1});
+    source0.buffer = getSpecificFile({ sampleRate: oac.sampleRate, numberOfChannels: 1 });
     source0.loop = true;
     source0.connect(oac.destination);
     source0.start(0);
@@ -34,9 +34,9 @@ registerTestCase({
 
 registerTestCase({
   func: function() {
-    var oac = new OfflineAudioContext(2, DURATION * samplerate, samplerate);
+    var oac = new OfflineAudioContext(2, DURATION * sampleRate, sampleRate);
     var source0 = oac.createBufferSource();
-    source0.buffer = getSpecificFile({rate: oac.samplerate, channels:2});
+    source0.buffer = getSpecificFile({ sampleRate: oac.sampleRate, numberOfChannels: 2 });
     source0.loop = true;
     source0.connect(oac.destination);
     source0.start(0);
@@ -47,10 +47,10 @@ registerTestCase({
 
 registerTestCase({
   func: function () {
-    var oac = new OfflineAudioContext(2, DURATION * samplerate, samplerate);
+    var oac = new OfflineAudioContext(2, DURATION * sampleRate, sampleRate);
     var source0 = oac.createBufferSource();
     var panner = oac.createPanner();
-    source0.buffer = getSpecificFile({rate: oac.samplerate, channels:2});
+    source0.buffer = getSpecificFile({ sampleRate: oac.sampleRate, numberOfChannels: 2 });
     source0.loop = true;
     panner.setPosition(1, 2, 3);
     panner.setOrientation(10, 10, 10);
@@ -64,9 +64,9 @@ registerTestCase({
 
 registerTestCase({
   func: function() {
-    var oac = new OfflineAudioContext(1, DURATION * samplerate, samplerate);
+    var oac = new OfflineAudioContext(1, DURATION * sampleRate, sampleRate);
     var source0 = oac.createBufferSource();
-    source0.buffer = getSpecificFile({rate: 38000, channels:1});
+    source0.buffer = getSpecificFile({ sampleRate: 38000, numberOfChannels: 1 });
     source0.loop = true;
     source0.connect(oac.destination);
     source0.start(0);
@@ -77,9 +77,9 @@ registerTestCase({
 
 registerTestCase({
   func: function() {
-    var oac = new OfflineAudioContext(2, DURATION * samplerate, samplerate);
+    var oac = new OfflineAudioContext(2, DURATION * sampleRate, sampleRate);
     var source0 = oac.createBufferSource();
-    source0.buffer = getSpecificFile({rate: 38000, channels:2});
+    source0.buffer = getSpecificFile({ sampleRate: 38000, numberOfChannels: 2 });
     source0.loop = true;
     source0.connect(oac.destination);
     source0.start(0);
@@ -90,10 +90,10 @@ registerTestCase({
 
 registerTestCase({
   func: function() {
-    var oac = new OfflineAudioContext(2, DURATION * samplerate, samplerate);
+    var oac = new OfflineAudioContext(2, DURATION * sampleRate, sampleRate);
     var source0 = oac.createBufferSource();
     var panner = oac.createPanner();
-    source0.buffer = getSpecificFile({rate: 38000, channels:2});
+    source0.buffer = getSpecificFile({ sampleRate: 38000, numberOfChannels: 2 });
     source0.loop = true;
     panner.setPosition(1, 2, 3);
     panner.setOrientation(10, 10, 10);
@@ -107,9 +107,9 @@ registerTestCase({
 
 registerTestCase({
   func: function() {
-    var oac = new OfflineAudioContext(2, DURATION * samplerate, samplerate);
+    var oac = new OfflineAudioContext(2, DURATION * sampleRate, sampleRate);
     var source0 = oac.createBufferSource();
-    source0.buffer = getSpecificFile({rate: oac.samplerate, channels:1});
+    source0.buffer = getSpecificFile({ sampleRate: oac.sampleRate, numberOfChannels: 1 });
     source0.loop = true;
     source0.connect(oac.destination);
     source0.start(0);
@@ -120,9 +120,9 @@ registerTestCase({
 
 registerTestCase({
   func: function() {
-    var oac = new OfflineAudioContext(1, DURATION * samplerate, samplerate);
+    var oac = new OfflineAudioContext(1, DURATION * sampleRate, sampleRate);
     var source0 = oac.createBufferSource();
-    source0.buffer = getSpecificFile({rate: oac.samplerate, channels:2});
+    source0.buffer = getSpecificFile({ sampleRate: oac.sampleRate, numberOfChannels: 2 });
     source0.loop = true;
     source0.connect(oac.destination);
     source0.start(0);
@@ -134,10 +134,10 @@ registerTestCase({
 registerTestCase({
   func: function() {
     var duration_adjusted = DURATION / 4;
-    var oac = new OfflineAudioContext(2, duration_adjusted * samplerate, samplerate);
+    var oac = new OfflineAudioContext(2, duration_adjusted * sampleRate, sampleRate);
     for (var i = 0; i < 100; i++) {
       var source0 = oac.createBufferSource();
-      source0.buffer = getSpecificFile({rate: 38000, channels:1});
+      source0.buffer = getSpecificFile({ sampleRate: 38000, numberOfChannels: 1 });
       source0.loop = true;
       source0.connect(oac.destination);
       source0.start(0);
@@ -150,8 +150,8 @@ registerTestCase({
 registerTestCase({
   func: function() {
     var duration_adjusted = DURATION / 4;
-    var oac = new OfflineAudioContext(2, duration_adjusted * samplerate, samplerate);
-    var reference = getSpecificFile({rate: 38000, channels:1}).getChannelData(0);
+    var oac = new OfflineAudioContext(2, duration_adjusted * sampleRate, sampleRate);
+    var reference = getSpecificFile({ sampleRate: 38000, numberOfChannels: 1 }).getChannelData(0);
     for (var i = 0; i < 100; i++) {
       var source0 = oac.createBufferSource();
       // copy the buffer into the a new one, so we know the implementation is not
@@ -173,7 +173,7 @@ registerTestCase({
 
 registerTestCase({
   func: function() {
-    var oac = new OfflineAudioContext(2, DURATION * samplerate, samplerate);
+    var oac = new OfflineAudioContext(2, DURATION * sampleRate, sampleRate);
     var gain = oac.createGain();
     gain.gain.value = -1;
     gain.connect(oac.destination);
@@ -186,7 +186,7 @@ registerTestCase({
     }
     for (var j = 0; j < 2; j++) {
       var sourcej = oac.createBufferSource();
-      sourcej.buffer = getSpecificFile({rate: 38000, channels:1});
+      sourcej.buffer = getSpecificFile({ sampleRate: 38000, numberOfChannels: 1 });
       sourcej.loop = true;
       sourcej.start(0);
       for (var i = 0; i < 4; i++) {
@@ -204,11 +204,11 @@ registerTestCase({
 registerTestCase({
   func: function() {
     var duration_adjusted = DURATION / 8;
-    var oac = new OfflineAudioContext(1, duration_adjusted * samplerate, samplerate);
+    var oac = new OfflineAudioContext(1, duration_adjusted * sampleRate, sampleRate);
     var i,l;
     var decay = 10;
     var duration = 4;
-    var len = samplerate * duration;
+    var len = sampleRate * duration;
     var buffer = ac.createBuffer(2, len, oac.sampleRate)
     var iL = buffer.getChannelData(0)
     var iR = buffer.getChannelData(1)
@@ -221,7 +221,7 @@ registerTestCase({
     convolver.buffer = buffer;
     convolver.connect(oac.destination);
 
-    var audiobuffer = getSpecificFile({rate: samplerate, channels:1});
+    var audiobuffer = getSpecificFile({ sampleRate: sampleRate, numberOfChannels: 1 });
     var source0 = oac.createBufferSource();
     source0.buffer = audiobuffer;
     source0.loop = true;
@@ -237,11 +237,11 @@ registerTestCase({
     // this test case is very slow in chrome, reduce the total duration to avoid
     // timeout
     var duration_adjusted = DURATION / 16;
-    var oac = new OfflineAudioContext(1, duration_adjusted * samplerate, samplerate);
-    var duration = duration_adjusted * samplerate;
-    var audiobuffer = getSpecificFile({rate: samplerate, channels:1});
+    var oac = new OfflineAudioContext(1, duration_adjusted * sampleRate, sampleRate);
+    var duration = duration_adjusted * sampleRate;
+    var audiobuffer = getSpecificFile({ sampleRate: sampleRate, numberOfChannels: 1 });
     var offset = 0;
-    while (offset < duration / samplerate) {
+    while (offset < duration / sampleRate) {
       var grain = oac.createBufferSource();
       var gain = oac.createGain();
       grain.connect(gain);
@@ -267,9 +267,9 @@ registerTestCase({
 
 registerTestCase({
   func: function() {
-    var samplerate = 44100;
+    var sampleRate = 44100;
     var duration  = DURATION;
-    var oac = new OfflineAudioContext(1, duration * samplerate, 44100);
+    var oac = new OfflineAudioContext(1, duration * sampleRate, 44100);
     var offset = 0;
     while (offset < duration) {
       var note = oac.createOscillator();
@@ -292,9 +292,9 @@ registerTestCase({
 
 registerTestCase({
   func: function() {
-    var samplerate = 44100;
+    var sampleRate = 44100;
     var duration  = DURATION;
-    var oac = new OfflineAudioContext(1, duration * samplerate, samplerate);
+    var oac = new OfflineAudioContext(1, duration * sampleRate, sampleRate);
     var offset = 0;
     var osc = oac.createOscillator();
     osc.type = "sawtooth";
@@ -323,10 +323,10 @@ registerTestCase({
 
 registerTestCase({
   func: function () {
-    var oac = new OfflineAudioContext(2, DURATION * samplerate, samplerate);
+    var oac = new OfflineAudioContext(2, DURATION * sampleRate, sampleRate);
     var source0 = oac.createBufferSource();
     var panner = oac.createStereoPanner();
-    source0.buffer = getSpecificFile({rate: oac.samplerate, channels:2});
+    source0.buffer = getSpecificFile({ sampleRate: oac.sampleRate, numberOfChannels: 2 });
     source0.loop = true;
     panner.pan = 0.1;
     source0.connect(panner);
@@ -339,10 +339,10 @@ registerTestCase({
 
 registerTestCase({
   func: function () {
-    var oac = new OfflineAudioContext(2, DURATION * samplerate, samplerate);
+    var oac = new OfflineAudioContext(2, DURATION * sampleRate, sampleRate);
     var source0 = oac.createBufferSource();
     var panner = oac.createStereoPanner();
-    source0.buffer = getSpecificFile({rate: oac.samplerate, channels:2});
+    source0.buffer = getSpecificFile({ sampleRate: oac.sampleRate, numberOfChannels: 2 });
     source0.loop = true;
     panner.pan.setValueAtTime(-0.1, 0.0);
     panner.pan.setValueAtTime(0.2, 0.5);
@@ -356,7 +356,7 @@ registerTestCase({
 
 registerTestCase({
   func: function () {
-    var oac = new OfflineAudioContext(2, DURATION * samplerate, samplerate);
+    var oac = new OfflineAudioContext(2, DURATION * sampleRate, sampleRate);
     var osc = oac.createOscillator();
     osc.type = 'sawtooth';
     var freq = 2000;

--- a/webaudio-bench.js
+++ b/webaudio-bench.js
@@ -18,8 +18,8 @@ if (location.search) {
 }
 
 
-// Global samplerate at which we run the context.
-var samplerate = 48000;
+// Global sample rate at which we run the context.
+var sampleRate = 48000;
 // Array containing at first the url of the audio resources to fetch, and the
 // the actual buffers audio buffer we have at our disposal to for tests.
 var sources = [];
@@ -35,17 +35,19 @@ var playingSource = null;
 // audiocontext used to play back the result of the benchmarks
 var ac = new AudioContext();
 
-function getFile(url, callback) {
+function getFile(source, callback) {
   var request = new XMLHttpRequest();
-  request.open("GET", url, true);
+  request.open("GET", source.url, true);
   request.responseType = "arraybuffer";
 
   request.onload = function() {
-    var ctx = new AudioContext();
-    ctx.decodeAudioData(request.response, function(data) {
-      callback(data, undefined);
+    // decode buffer at its initial sample rate
+    var ctx = new OfflineAudioContext(1, 1, source.sampleRate);
+
+    ctx.decodeAudioData(request.response, function(buffer) {
+      callback(buffer, undefined);
     }, function() {
-      callback(undefined, "Error decoding the file " + url);
+      callback(undefined, "Error decoding the file " + source.url);
     });
   }
   request.send();
@@ -74,11 +76,11 @@ function benchmark(testcase, ended) {
 }
 
 function getMonoFile() {
-  return getSpecificFile({numberOfChannels: 1});
+  return getSpecificFile({ numberOfChannels: 1 });
 }
 
 function getStereoFile() {
-  return getSpecificFile({numberOfChannels: 2});
+  return getSpecificFile({ numberOfChannels: 2 });
 }
 
 function matchIfSpecified(a, b) {
@@ -91,10 +93,12 @@ function matchIfSpecified(a, b) {
 function getSpecificFile(spec) {
   for (var i = 0 ; i < sources.length; i++) {
     if (matchIfSpecified(sources[i].numberOfChannels, spec.numberOfChannels) &&
-        matchIfSpecified(sources[i].samplerate, spec.samplerate)) {
+        matchIfSpecified(sources[i].sampleRate, spec.sampleRate)) {
       return sources[i];
     }
   }
+
+  console.log(spec);
   throw new Error("Could not find a file that matches the specs.");
 }
 
@@ -188,15 +192,20 @@ function initAll() {
 }
 
 function loadOne(i, endCallback) {
-  getFile(sources[i], function(b) {
-    sources[i] = b;
+  getFile(sources[i], function(buffer, err) {
+    if (err) {
+      throw new Error(msg);
+    }
+
+    sources[i] = buffer;
     i++;
-    if (i == sources.length) {
-      loadOne(i);
+
+    if (i < sources.length) {
+      loadOne(i, endCallback);
     } else {
       endCallback();
     }
-  })
+  });
 }
 
 function loadAllSources(endCallback) {


### PR DESCRIPTION
Hey, 

So, I mainly changed the way the samples are loaded, decoded and retrieved, only the first one was actually loaded (already resampled to system/default sample rate) and retrieved in all tests.

The second commit is only some changes in the naming of the tests, this can be reverted back maybe it could break some long term stats you make.

Let me know if I missed something